### PR TITLE
Remove package manager restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This action creates a new release branch and PR. It also makes a commit that includes any release preparation that can be easily automated, which includes version bumps and a partial changelog updates (using `@metamask/auto-changelog`).
 
+This action is only tested with Yarn v1.
+
 ### Monorepos
 
 This action is compatible with monorepos, but only if they use workspaces. It uses the `workspaces` property of `package.json` to determine if the repo is a monorepo, and to find each workspace.

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
   ],
   "main": "lib/index.js",
   "engines": {
-    "node": ">=12.10.0",
-    "yarn": ">=1.22.0 <2.0.0"
+    "node": ">=12.10.0"
   },
   "scripts": {
     "setup": "yarn install && yarn setup:postinstall",


### PR DESCRIPTION
The `engines` entry that requires the use of Yarn v1 has been removed. I suspect this is compatible with both npm and Yarn v2, but we haven't tested this. Just in case we're wrong, the README has been updated to say that we only test this with Yarn v1