### PR TITLE
Change release branch prefix from 'release-v' to 'release/'

### DIFF
--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -12,7 +12,7 @@ if [[ -z $NEW_VERSION ]]; then
   exit 1
 fi
 
-RELEASE_BRANCH_NAME="release/${NEW_VERSION}"
+RELEASE_BRANCH_NAME="automation_release-${NEW_VERSION}"
 RELEASE_BODY="This is the release candidate for version ${NEW_VERSION}."
 
 git config user.name github-actions

--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -12,7 +12,7 @@ if [[ -z $NEW_VERSION ]]; then
   exit 1
 fi
 
-RELEASE_BRANCH_NAME="release-v${NEW_VERSION}"
+RELEASE_BRANCH_NAME="release/${NEW_VERSION}"
 RELEASE_BODY="This is the release candidate for version ${NEW_VERSION}."
 
 git config user.name github-actions


### PR DESCRIPTION
Since we're using the prefix of branch names created by this Action to trigger `action-publish-release`, it seems useful to ensure that we will _never_ in practice manually create a branch whose name collides with said prefix. Usually, branch names at MetaMask are snake-case, and at times contain forward slashes (`/`). Rarely if ever do we use underscores. Therefore, prefixing automation-related branch names with `automation_` seems like a dependable way to distinguish them from "regular" branches.

Since the branches created by this Action are intended to be version-tagged and published as GitHub releases, creating branches named `automation_release-<version>`, where `<version>` is a plain, un-prefixed SemVer version (e.g. `1.0.0`), seems like a good solution.