### PR TITLE
Add release branch prefix input

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The SemVer version being released is appended to the prefix.
 The default prefix is `automation_release-`, which creates branches named e.g. `automation_release-1.0.0`.
 
 If this Action is used with [MetaMask/action-publish-release](https://github.com/MetaMask/action-publish-release), both Actions must be configured to use the same branch prefix.
-Their branch prefix defaults are the same across major versions.
+Their branch prefix defaults are the same within major versions.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ jobs:
           release-version: ${{ github.event.inputs.release-version }}
 ```
 
+### Release Branch Names
+
+Optionally, a `release-branch-prefix` input can be specified to the Action, which will be used as the prefix for the names of release PR branches.
+The SemVer version being released is appended to the prefix.
+The default prefix is `automation_release-`, which creates branches named e.g. `automation_release-1.0.0`.
+
+If this Action is used with [MetaMask/action-publish-release](https://github.com/MetaMask/action-publish-release), both Actions must be configured to use the same branch prefix.
+Their branch prefix defaults are the same across major versions.
+
 ## Contributing
 
 ### Setup

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This action uses a synchronized versioning strategy, meaning that the version of
 
 This Action can be used on its own, but we recommend using it with [MetaMask/action-publish-release](https://github.com/MetaMask/action-publish-release).
 
+In order for this action to run, the project must have a [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)-compatible changelog, even if it's empty.
+
 Add the following workflow file to your repository in the path `.github/workflows/create-release-pr.yml`:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ jobs:
 
 ### Release Branch Names
 
-Optionally, a `release-branch-prefix` input can be specified to the Action, which will be used as the prefix for the names of release PR branches.
+A `release-branch-prefix` input must be specified to the Action, which will be used as the prefix for the names of release PR branches.
 The SemVer version being released is appended to the prefix.
 The default prefix is `automation_release-`, which creates branches named e.g. `automation_release-1.0.0`.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This action uses a synchronized versioning strategy, meaning that the version of
 
 This Action can be used on its own, but we recommend using it with [MetaMask/action-publish-release](https://github.com/MetaMask/action-publish-release).
 
-Add the following Workflow File to your repository in the path `.github/workflows/create-release-pr.yml`:
+Add the following workflow file to your repository in the path `.github/workflows/create-release-pr.yml`:
 
 ```yaml
 name: Create Release Pull Request

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,10 @@ name: 'Create Release PR'
 description: "Update a repository's npm package(s). Monorepo-compatible."
 
 inputs:
+  release-branch-prefix:
+    description: "The prefix of the release PR branch name, to which the release's SemVer version will be appended."
+    default: 'automation_release-'
+    required: true
   release-type:
     description: 'A SemVer version diff, e.g. "major", "minor", or "patch". Mutually exclusive with "release-version".'
     required: false
@@ -20,4 +24,6 @@ runs:
         RELEASE_VERSION: ${{ inputs.release-version }}
     - id: create-release-pr
       shell: bash
-      run: ${{ github.action_path }}/scripts/create-release-pr.sh ${{ steps.update-packages.outputs.NEW_VERSION }}
+      run: ${{ github.action_path }}/scripts/create-release-pr.sh \
+        ${{ steps.update-packages.outputs.NEW_VERSION }} \
+        ${{ inputs.release-branch-prefix }}

--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -2,7 +2,6 @@
 
 set -x
 set -e
-set -u
 set -o pipefail
 
 NEW_VERSION="${1}"
@@ -12,7 +11,14 @@ if [[ -z $NEW_VERSION ]]; then
   exit 1
 fi
 
-RELEASE_BRANCH_NAME="automation_release-${NEW_VERSION}"
+RELEASE_BRANCH_PREFIX="${2}"
+
+if [[ -z $RELEASE_BRANCH_PREFIX ]]; then
+  echo "Error: No release branch prefix specified."
+  exit 1
+fi
+
+RELEASE_BRANCH_NAME="${RELEASE_BRANCH_PREFIX}${NEW_VERSION}"
 RELEASE_BODY="This is the release candidate for version ${NEW_VERSION}."
 
 git config user.name github-actions


### PR DESCRIPTION
Adds a branch prefix input, so that the release branch prefix is configurable for both this Action and `action-publish-release`.