### PR TITLE
Remove ' RC' suffix from PR title

### DIFF
--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -36,6 +36,6 @@ git push --set-upstream origin "${RELEASE_BRANCH_NAME}"
 
 gh pr create \
   --draft \
-  --title "${NEW_VERSION} RC" \
+  --title "${NEW_VERSION}" \
   --body "${RELEASE_BODY}" \
   --head "${RELEASE_BRANCH_NAME}";


### PR DESCRIPTION
Removes the ` RC`-suffix from the PR title, making it just the SemVer version.