### PR TITLE
Fix release branch prefix input in local workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -23,3 +23,5 @@ jobs:
       - uses: MetaMask/action-publish-release@v0.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          release-branch-prefix: release/


### PR DESCRIPTION
I forgot to update the input to `publish-release`.