### PR TITLE
Automate shorthand major version tag updating

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,7 +21,10 @@ jobs:
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       - uses: MetaMask/action-publish-release@v1
+        id: publish-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           release-branch-prefix: release/
+      - name: Update shorthand major version tag
+        run: ./scripts/update-major-version-tag.sh ${{ steps.publish-release.outputs.RELEASE_VERSION }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -24,7 +24,5 @@ jobs:
         id: publish-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          release-branch-prefix: release/
       - name: Update shorthand major version tag
         run: ./scripts/update-major-version-tag.sh ${{ steps.publish-release.outputs.RELEASE_VERSION }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -14,6 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          # This is to guarantee that the most recent tag is fetched.
+          fetch-depth: 0
+          # We check out the release pull request's base branch, which will be
+          # used as the base branch for all git operations.
+          ref: ${{ github.event.pull_request.base.ref }}
       - name: Get Node.js version
         id: nvm
         run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -25,4 +25,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Update shorthand major version tag
-        run: ./scripts/update-major-version-tag.sh ${{ steps.publish-release.outputs.RELEASE_VERSION }}
+        run: ./scripts/update-major-version-tag.sh ${{ steps.publish-release.outputs.release-version }}

--- a/scripts/update-major-version-tag.sh
+++ b/scripts/update-major-version-tag.sh
@@ -7,7 +7,7 @@ set -o pipefail
 RELEASE_VERSION="${1}"
 
 if [[ -z $RELEASE_VERSION ]]; then
-  echo "Error: No new version specified."
+  echo "Error: No release version specified."
   exit 1
 fi
 

--- a/scripts/update-major-version-tag.sh
+++ b/scripts/update-major-version-tag.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+set -o pipefail
+
+RELEASE_VERSION="${1}"
+
+if [[ -z $RELEASE_VERSION ]]; then
+  echo "Error: No new version specified."
+  exit 1
+fi
+
+MAJOR_VERSION_TAG="v${RELEASE_VERSION/\.*/}"
+
+git config user.name github-actions
+git config user.email github-actions@github.com
+
+if git show-ref --tags "$MAJOR_VERSION_TAG" --quiet; then
+  echo "Tag ${MAJOR_VERSION_TAG} exists, attempting to delete it."
+  git tag --delete "$MAJOR_VERSION_TAG"
+  git push --delete origin "$MAJOR_VERSION_TAG"
+else 
+  echo "Tag ${MAJOR_VERSION_TAG} does not exist, creating it from scratch."
+fi
+
+git tag "$MAJOR_VERSION_TAG" HEAD
+git push --tags
+echo "Updated shorthand major version tag."
+
+echo "::set-output name=MAJOR_VERSION_TAG::$MAJOR_VERSION_TAG"


### PR DESCRIPTION
Automate the updating of the shorthand major version tag (e.g. `v1`) at the end of the `publish-release` workflow. To facilitate updating this tag, `actions/checkout` now fetches the entire git history. We also set the base branch for all git operations in that workflow to the release pull request base branch, so that we can release branches other than `main`.

While we're here, also removes an input to the `publish-release` action in that workflow that is no longer necessary under the new versioning scheme.