### PR TITLE
Improve local workflow documentation

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,7 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          # This is to guarantee that the most recent tag is fetched.
+          # This is to guarantee that the most recent tag is fetched,
+          # which we need for updating the shorthand major version tag.
           fetch-depth: 0
           # We check out the release pull request's base branch, which will be
           # used as the base branch for all git operations.


### PR DESCRIPTION
Document why we fetch the complete git history in the `publish-release` workflow.