### PR TITLE
Add debug logging

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -11540,6 +11540,7 @@ function validateVersion(currentVersion, newVersion, tags) {
 
 
 performUpdate(getActionInputs()).catch((error) => {
+    (0,core.error)((error === null || error === void 0 ? void 0 : error.stack) || 'The error has no stack.');
     (0,core.setFailed)(error);
 });
 //# sourceMappingURL=index.js.map

--- a/dist/index.js
+++ b/dist/index.js
@@ -11540,7 +11540,7 @@ function validateVersion(currentVersion, newVersion, tags) {
 
 
 performUpdate(getActionInputs()).catch((error) => {
-    (0,core.error)((error === null || error === void 0 ? void 0 : error.stack) || 'The error has no stack.');
+    (0,core.error)(error.stack);
     (0,core.setFailed)(error);
 });
 //# sourceMappingURL=index.js.map

--- a/dist/index.js
+++ b/dist/index.js
@@ -11540,7 +11540,10 @@ function validateVersion(currentVersion, newVersion, tags) {
 
 
 performUpdate(getActionInputs()).catch((error) => {
-    (0,core.error)(error.stack);
+    // istanbul ignore else
+    if (error.stack) {
+        (0,core.error)(error.stack);
+    }
     (0,core.setFailed)(error);
 });
 //# sourceMappingURL=index.js.map

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4,6 +4,7 @@ import * as utils from './utils';
 
 jest.mock('@actions/core', () => {
   return {
+    error: jest.fn(),
     setFailed: jest.fn(),
   };
 });
@@ -32,6 +33,7 @@ describe('main entry file', () => {
       .mockImplementationOnce(async () => {
         throw new Error('error');
       });
+    const logErrorMock = jest.spyOn(actionsCore, 'error');
     const setFailedMock = jest.spyOn(actionsCore, 'setFailed');
 
     import('.');
@@ -39,6 +41,7 @@ describe('main entry file', () => {
       setImmediate(() => {
         expect(getActionInputsMock).toHaveBeenCalledTimes(1);
         expect(performUpdateMock).toHaveBeenCalledTimes(1);
+        expect(logErrorMock).toHaveBeenCalledTimes(1);
         expect(setFailedMock).toHaveBeenCalledTimes(1);
         expect(setFailedMock).toHaveBeenCalledWith(new Error('error'));
         resolve();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
-import { setFailed as setActionToFailed } from '@actions/core';
+import { error as logError, setFailed as setActionToFailed } from '@actions/core';
 import { performUpdate } from './update';
 import { getActionInputs } from './utils';
 
 performUpdate(getActionInputs()).catch((error) => {
+  logError(error?.stack || 'The error has no stack.');
   setActionToFailed(error);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,7 @@
-import { error as logError, setFailed as setActionToFailed } from '@actions/core';
+import {
+  error as logError,
+  setFailed as setActionToFailed,
+} from '@actions/core';
 import { performUpdate } from './update';
 import { getActionInputs } from './utils';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,9 @@ import { performUpdate } from './update';
 import { getActionInputs } from './utils';
 
 performUpdate(getActionInputs()).catch((error) => {
-  logError(error.stack);
+  // istanbul ignore else
+  if (error.stack) {
+    logError(error.stack);
+  }
   setActionToFailed(error);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,6 @@ import { performUpdate } from './update';
 import { getActionInputs } from './utils';
 
 performUpdate(getActionInputs()).catch((error) => {
-  logError(error?.stack || 'The error has no stack.');
+  logError(error.stack);
   setActionToFailed(error);
 });


### PR DESCRIPTION
The `setFailed` function of `@actions/core` only logs `error.toString()`, which doesn't include the error stack trace. This PR adds a call to the `error` function of that package. We could use `debug`, but then you have to add a repository secret to enable debug logging. This log should always be visible. See the package website for details: https://www.npmjs.com/package/@actions/core