### PR TITLE
Synchronize monorepo packages for versions in range ^0.x.x

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -12222,6 +12222,9 @@ var diff_default = /*#__PURE__*/__nccwpck_require__.n(diff);
 // EXTERNAL MODULE: ./node_modules/semver/functions/gt.js
 var gt = __nccwpck_require__(4123);
 var gt_default = /*#__PURE__*/__nccwpck_require__.n(gt);
+// EXTERNAL MODULE: ./node_modules/semver/functions/major.js
+var major = __nccwpck_require__(6688);
+var major_default = /*#__PURE__*/__nccwpck_require__.n(major);
 // EXTERNAL MODULE: ./node_modules/@metamask/action-utils/dist/index.js
 var dist = __nccwpck_require__(1281);
 // EXTERNAL MODULE: ./node_modules/semver/functions/clean.js
@@ -12695,6 +12698,7 @@ function isMonorepoUpdateSpecification(specification) {
 
 
 
+
 /**
  * Action entry function. Gets git tags, reads the work space root package.json,
  * and updates the package(s) of the repository per the Action inputs.
@@ -12761,10 +12765,11 @@ async function updatePolyrepo(newVersion, manifest, repositoryUrl) {
  * tag --merged".
  */
 async function updateMonorepo(newVersion, versionDiff, rootManifest, repositoryUrl, tags) {
-    // If the version bump is major, we will synchronize the versions of all
-    // monorepo packages, meaning the "version" field of their manifests and
-    // their version range specified wherever they appear as a dependency.
-    const synchronizeVersions = (0,dist.isMajorSemverDiff)(versionDiff);
+    // If the version bump is major or the new major version is still "0", we
+    // synchronize the versions of all monorepo packages, meaning the "version"
+    // field of their manifests and their version range specified wherever they
+    // appear as a dependency.
+    const synchronizeVersions = (0,dist.isMajorSemverDiff)(versionDiff) || major_default()(newVersion) === 0;
     // Collect required information to perform updates
     const allPackages = await getMetadataForAllPackages(rootManifest.workspaces);
     const packagesToUpdate = await getPackagesToUpdate(allPackages, synchronizeVersions, tags);

--- a/src/update.test.ts
+++ b/src/update.test.ts
@@ -224,6 +224,89 @@ describe('performUpdate', () => {
     expect(setActionOutputMock).toHaveBeenCalledWith('NEW_VERSION', newVersion);
   });
 
+  it('updates a monorepo with major version "0"', async () => {
+    const rootManifestName = 'root';
+    const oldVersion = '0.1.0';
+    const newVersion = '0.2.0';
+    const workspaces: readonly string[] = ['a', 'b', 'c'];
+
+    getTagsMock.mockImplementationOnce(async () => [
+      new Set(['v0.0.0', 'v0.1.0']),
+      'v0.1.0',
+    ]);
+
+    getPackageManifestMock.mockImplementationOnce(async () => {
+      return {
+        name: rootManifestName,
+        version: oldVersion,
+        private: true,
+        workspaces: [...workspaces],
+      };
+    });
+
+    const getPackagesMetadataMock = jest
+      .spyOn(packageOperations, 'getMetadataForAllPackages')
+      .mockImplementationOnce(async () => {
+        return { a: {}, b: {}, c: {} } as any;
+      });
+
+    const getPackagesToUpdateMock = jest
+      .spyOn(packageOperations, 'getPackagesToUpdate')
+      .mockImplementationOnce(async () => new Set(workspaces));
+
+    await performUpdate({ ReleaseType: null, ReleaseVersion: newVersion });
+
+    expect(getRepositoryHttpsUrlMock).toHaveBeenCalledTimes(1);
+    expect(getTagsMock).toHaveBeenCalledTimes(1);
+    expect(consoleLogMock).toHaveBeenCalledTimes(1);
+    expect(consoleLogMock).toHaveBeenCalledWith(
+      expect.stringMatching(/Applying monorepo workflow/u),
+    );
+    expect(getPackagesMetadataMock).toHaveBeenCalledTimes(1);
+
+    expect(getPackagesToUpdateMock).toHaveBeenCalledTimes(1);
+    expect(getPackagesToUpdateMock).toHaveBeenCalledWith(
+      { a: {}, b: {}, c: {} },
+      true,
+      new Set(['v0.0.0', 'v0.1.0']),
+    );
+
+    expect(packageOperations.updatePackages).toHaveBeenCalledTimes(1);
+    expect(packageOperations.updatePackages).toHaveBeenCalledWith(
+      { a: {}, b: {}, c: {} },
+      {
+        newVersion,
+        packagesToUpdate: new Set(workspaces),
+        repositoryUrl: mockRepoUrl,
+        shouldUpdateChangelog: true,
+        synchronizeVersions: true,
+      },
+    );
+
+    expect(packageOperations.updatePackage).toHaveBeenCalledTimes(1);
+    expect(packageOperations.updatePackage).toHaveBeenCalledWith(
+      {
+        dirPath: './',
+        manifest: {
+          name: rootManifestName,
+          private: true,
+          version: oldVersion,
+          workspaces: [...workspaces],
+        },
+      },
+      {
+        newVersion,
+        packagesToUpdate: new Set(workspaces),
+        repositoryUrl: mockRepoUrl,
+        shouldUpdateChangelog: false,
+        synchronizeVersions: true,
+      },
+    );
+
+    expect(setActionOutputMock).toHaveBeenCalledTimes(1);
+    expect(setActionOutputMock).toHaveBeenCalledWith('NEW_VERSION', newVersion);
+  });
+
   it('throws if the new version is less than the current version', async () => {
     const packageName = 'A';
     const oldVersion = '1.1.0';

--- a/src/update.test.ts
+++ b/src/update.test.ts
@@ -141,7 +141,7 @@ describe('performUpdate', () => {
     expect(setActionOutputMock).toHaveBeenCalledWith('NEW_VERSION', newVersion);
   });
 
-  it('updates a monorepo', async () => {
+  it('updates a monorepo (major version bump)', async () => {
     const rootManifestName = 'root';
     const oldVersion = '1.1.0';
     const newVersion = '2.0.0';
@@ -224,7 +224,90 @@ describe('performUpdate', () => {
     expect(setActionOutputMock).toHaveBeenCalledWith('NEW_VERSION', newVersion);
   });
 
-  it('updates a monorepo with major version "0"', async () => {
+  it('updates a monorepo (non-major version bump)', async () => {
+    const rootManifestName = 'root';
+    const oldVersion = '1.1.0';
+    const newVersion = '1.2.0';
+    const workspaces: readonly string[] = ['a', 'b', 'c'];
+
+    getTagsMock.mockImplementationOnce(async () => [
+      new Set(['v1.0.0', 'v1.1.0']),
+      'v1.1.0',
+    ]);
+
+    getPackageManifestMock.mockImplementationOnce(async () => {
+      return {
+        name: rootManifestName,
+        version: oldVersion,
+        private: true,
+        workspaces: [...workspaces],
+      };
+    });
+
+    const getPackagesMetadataMock = jest
+      .spyOn(packageOperations, 'getMetadataForAllPackages')
+      .mockImplementationOnce(async () => {
+        return { a: {}, b: {}, c: {} } as any;
+      });
+
+    const getPackagesToUpdateMock = jest
+      .spyOn(packageOperations, 'getPackagesToUpdate')
+      .mockImplementationOnce(async () => new Set(workspaces));
+
+    await performUpdate({ ReleaseType: null, ReleaseVersion: newVersion });
+
+    expect(getRepositoryHttpsUrlMock).toHaveBeenCalledTimes(1);
+    expect(getTagsMock).toHaveBeenCalledTimes(1);
+    expect(consoleLogMock).toHaveBeenCalledTimes(1);
+    expect(consoleLogMock).toHaveBeenCalledWith(
+      expect.stringMatching(/Applying monorepo workflow/u),
+    );
+    expect(getPackagesMetadataMock).toHaveBeenCalledTimes(1);
+
+    expect(getPackagesToUpdateMock).toHaveBeenCalledTimes(1);
+    expect(getPackagesToUpdateMock).toHaveBeenCalledWith(
+      { a: {}, b: {}, c: {} },
+      false,
+      new Set(['v1.0.0', 'v1.1.0']),
+    );
+
+    expect(packageOperations.updatePackages).toHaveBeenCalledTimes(1);
+    expect(packageOperations.updatePackages).toHaveBeenCalledWith(
+      { a: {}, b: {}, c: {} },
+      {
+        newVersion,
+        packagesToUpdate: new Set(workspaces),
+        repositoryUrl: mockRepoUrl,
+        shouldUpdateChangelog: true,
+        synchronizeVersions: false,
+      },
+    );
+
+    expect(packageOperations.updatePackage).toHaveBeenCalledTimes(1);
+    expect(packageOperations.updatePackage).toHaveBeenCalledWith(
+      {
+        dirPath: './',
+        manifest: {
+          name: rootManifestName,
+          private: true,
+          version: oldVersion,
+          workspaces: [...workspaces],
+        },
+      },
+      {
+        newVersion,
+        packagesToUpdate: new Set(workspaces),
+        repositoryUrl: mockRepoUrl,
+        shouldUpdateChangelog: false,
+        synchronizeVersions: false,
+      },
+    );
+
+    expect(setActionOutputMock).toHaveBeenCalledTimes(1);
+    expect(setActionOutputMock).toHaveBeenCalledWith('NEW_VERSION', newVersion);
+  });
+
+  it('updates a monorepo (within major version 0)', async () => {
     const rootManifestName = 'root';
     const oldVersion = '0.1.0';
     const newVersion = '0.2.0';

--- a/src/update.ts
+++ b/src/update.ts
@@ -2,6 +2,7 @@ import { setOutput as setActionOutput } from '@actions/core';
 import semverIncrement from 'semver/functions/inc';
 import semverDiff from 'semver/functions/diff';
 import semverGt from 'semver/functions/gt';
+import semverMajor from 'semver/functions/major';
 import type { ReleaseType as SemverReleaseType } from 'semver';
 import {
   getPackageManifest,
@@ -129,10 +130,11 @@ async function updateMonorepo(
   repositoryUrl: string,
   tags: ReadonlySet<string>,
 ): Promise<void> {
-  // If the version bump is major, we will synchronize the versions of all
-  // monorepo packages, meaning the "version" field of their manifests and
-  // their version range specified wherever they appear as a dependency.
-  const synchronizeVersions = isMajorSemverDiff(versionDiff);
+  // If the version bump is major or the new major version is still "0", we
+  // synchronize the versions of all monorepo packages, meaning the "version"
+  // field of their manifests and their version range specified wherever they
+  // appear as a dependency.
+  const synchronizeVersions = isMajorSemverDiff(versionDiff) || semverMajor(newVersion) === 0;
 
   // Collect required information to perform updates
   const allPackages = await getMetadataForAllPackages(rootManifest.workspaces);

--- a/src/update.ts
+++ b/src/update.ts
@@ -134,7 +134,8 @@ async function updateMonorepo(
   // synchronize the versions of all monorepo packages, meaning the "version"
   // field of their manifests and their version range specified wherever they
   // appear as a dependency.
-  const synchronizeVersions = isMajorSemverDiff(versionDiff) || semverMajor(newVersion) === 0;
+  const synchronizeVersions =
+    isMajorSemverDiff(versionDiff) || semverMajor(newVersion) === 0;
 
   // Collect required information to perform updates
   const allPackages = await getMetadataForAllPackages(rootManifest.workspaces);


### PR DESCRIPTION
Monorepo package versions should always be synchronized if the major version is zero, because any bump within major version zero can be breaking per SemVer conventions.