### PR TITLE
Add version synchronization strategies

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -14,8 +14,14 @@ on:
         description: 'A specific version to bump to. Mutually exclusive with "release-type".'
         required: false
       version-synchronization-strategy:
+        type: choice
         description: 'Monorepos only. Whether and how to synchronize monorepo package versions. See Action readme for details.'
         required: false
+        options:
+          - all
+          - transitive
+          - internalOnly
+          - none
 
 jobs:
   create-release-pr:

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -17,6 +17,7 @@ on:
         type: choice
         description: 'Monorepos only. Whether and how to synchronize monorepo package versions. See Action readme for details.'
         required: false
+        default: 'transitive'
         options:
           - fixed
           - transitive

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -13,6 +13,9 @@ on:
       release-version:
         description: 'A specific version to bump to. Mutually exclusive with "release-type".'
         required: false
+      version-synchronization-strategy:
+        description: 'Monorepos only. Whether and how to synchronize monorepo package versions. See Action readme for details.'
+        required: false
 
 jobs:
   create-release-pr:
@@ -39,9 +42,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          artifacts-path: gh-action__release-authors
           release-type: ${{ github.event.inputs.release-type }}
           release-version: ${{ github.event.inputs.release-version }}
-          artifacts-path: gh-action__release-authors
+          version-synchronization-strategy: ${{ github.event.inputs.version-synchronization-strategy }}
       # Upload the release author artifact for use in subsequent workflows
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -18,10 +18,9 @@ on:
         description: 'Monorepos only. Whether and how to synchronize monorepo package versions. See Action readme for details.'
         required: false
         options:
-          - all
+          - fixed
           - transitive
-          - internalOnly
-          - none
+          - independent
 
 jobs:
   create-release-pr:

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,13 @@ name: 'Create Release PR'
 description: "Update a repository's npm package(s). Monorepo-compatible."
 
 inputs:
+  artifacts-path:
+    description: 'The path to the directory where this action will create its artifact files.'
+    required: false
+  created-pr-status:
+    default: 'draft'
+    description: 'The status of the pull request when created. Allowed options are "draft" and "open".'
+    required: true
   release-branch-prefix:
     description: "The prefix of the release PR branch name, to which the release's SemVer version will be appended."
     default: 'release/'
@@ -12,13 +19,9 @@ inputs:
   release-version:
     description: 'A plain SemVer version string, specifying the version to bump to. Mutually exclusive with "release-type".'
     required: false
-  artifacts-path:
-    description: 'The path to the directory where this action will create its artifact files.'
+  version-synchronization-strategy:
+    description: 'Monorepos only. Whether and how to synchronize monorepo package versions. See Action readme for details.'
     required: false
-  created-pr-status:
-    default: 'draft'
-    description: 'The status of the pull request when created. Allowed options are "draft" and "open"'
-    required: true
 
 runs:
   using: 'composite'
@@ -29,6 +32,7 @@ runs:
       env:
         RELEASE_TYPE: ${{ inputs.release-type }}
         RELEASE_VERSION: ${{ inputs.release-version }}
+        VERSION_SYNCHRONIZATION_STRATEGY: ${{ inputs.version-synchronization-strategy}}
     - id: create-release-pr
       shell: bash
       run: |

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@actions/core": "^1.2.7",
     "@metamask/action-utils": "^0.0.2",
     "@metamask/auto-changelog": "^2.4.0",
+    "dependency-graph": "^0.11.0",
     "execa": "^4.1.0",
     "glob": "^7.1.7",
     "semver": "^7.3.5"

--- a/src/git-operations.test.ts
+++ b/src/git-operations.test.ts
@@ -163,7 +163,9 @@ describe('getTags', () => {
 
 describe('didPackageChange', () => {
   it('returns true if there are no tags', async () => {
-    expect(await didPackageChange(new Set(), {} as any)).toStrictEqual(true);
+    expect(await didPackageChange(new Set(), {} as any, '/foo')).toStrictEqual(
+      true,
+    );
     expect(execaMock).not.toHaveBeenCalled();
   });
 
@@ -173,32 +175,29 @@ describe('didPackageChange', () => {
     });
 
     expect(
-      await didPackageChange(PARSED_MOCK_TAGS, {
-        name: PACKAGES.A.name,
-        manifest: { name: PACKAGES.A.name, version: VERSIONS.First },
-        dirName: PACKAGES.A.dir,
-        dirPath: `packages/${PACKAGES.A.dir}`,
-      }),
+      await didPackageChange(
+        PARSED_MOCK_TAGS,
+        { name: PACKAGES.A.name, version: VERSIONS.First },
+        `packages/${PACKAGES.A.dir}`,
+      ),
     ).toStrictEqual(true);
     expect(
-      await didPackageChange(PARSED_MOCK_TAGS, {
-        name: PACKAGES.B.name,
-        manifest: { name: PACKAGES.B.name, version: VERSIONS.First },
-        dirName: PACKAGES.B.dir,
-        dirPath: `packages/${PACKAGES.B.dir}`,
-      }),
+      await didPackageChange(
+        PARSED_MOCK_TAGS,
+        { name: PACKAGES.B.name, version: VERSIONS.First },
+        `packages/${PACKAGES.B.dir}`,
+      ),
     ).toStrictEqual(true);
     expect(execaMock).toHaveBeenCalledTimes(1);
   });
 
   it('repeat call for tag retrieves result from cache', async () => {
     expect(
-      await didPackageChange(PARSED_MOCK_TAGS, {
-        name: PACKAGES.A.name,
-        manifest: { name: PACKAGES.A.name, version: VERSIONS.First },
-        dirName: PACKAGES.A.dir,
-        dirPath: `packages/${PACKAGES.A.dir}`,
-      }),
+      await didPackageChange(
+        PARSED_MOCK_TAGS,
+        { name: PACKAGES.A.name, version: VERSIONS.First },
+        `packages/${PACKAGES.A.dir}`,
+      ),
     ).toStrictEqual(true);
     expect(execaMock).not.toHaveBeenCalled();
   });
@@ -209,32 +208,29 @@ describe('didPackageChange', () => {
     });
 
     expect(
-      await didPackageChange(PARSED_MOCK_TAGS, {
-        name: PACKAGES.A.name,
-        manifest: { name: PACKAGES.A.name, version: VERSIONS.Second },
-        dirName: PACKAGES.A.dir,
-        dirPath: `packages/${PACKAGES.A.dir}`,
-      }),
+      await didPackageChange(
+        PARSED_MOCK_TAGS,
+        { name: PACKAGES.A.name, version: VERSIONS.Second },
+        `packages/${PACKAGES.A.dir}`,
+      ),
     ).toStrictEqual(true);
     expect(
-      await didPackageChange(PARSED_MOCK_TAGS, {
-        name: PACKAGES.B.name,
-        manifest: { name: PACKAGES.B.name, version: VERSIONS.Second },
-        dirName: PACKAGES.B.dir,
-        dirPath: `packages/${PACKAGES.B.dir}`,
-      }),
+      await didPackageChange(
+        PARSED_MOCK_TAGS,
+        { name: PACKAGES.B.name, version: VERSIONS.Second },
+        `packages/${PACKAGES.B.dir}`,
+      ),
     ).toStrictEqual(false);
     expect(execaMock).toHaveBeenCalledTimes(1);
   });
 
   it('throws if package manifest specifies version without tag', async () => {
     await expect(
-      didPackageChange(PARSED_MOCK_TAGS, {
-        name: PACKAGES.A.name,
-        manifest: { name: PACKAGES.A.name, version: '2.0.0' },
-        dirName: PACKAGES.A.dir,
-        dirPath: `packages/${PACKAGES.A.dir}`,
-      }),
+      didPackageChange(
+        PARSED_MOCK_TAGS,
+        { name: PACKAGES.A.name, version: '2.0.0' },
+        `packages/${PACKAGES.A.dir}`,
+      ),
     ).rejects.toThrow(/no corresponding tag/u);
     expect(execaMock).not.toHaveBeenCalled();
   });

--- a/src/graph-utils.test.ts
+++ b/src/graph-utils.test.ts
@@ -1,0 +1,13 @@
+import { DepGraph } from 'dependency-graph';
+import {
+  getInternalDependencies,
+  getMonorepoDependencyGraph,
+} from './graph-utils';
+
+describe('getMonorepoDependencyGraph', () => {
+  it.todo('does the thing');
+});
+
+describe('getInternalDependencies', () => {
+  it.todo('does the thing');
+});

--- a/src/graph-utils.ts
+++ b/src/graph-utils.ts
@@ -1,0 +1,68 @@
+import {
+  ManifestDependencyFieldNames,
+  PackageManifest,
+} from '@metamask/action-utils';
+import { DepGraph } from 'dependency-graph';
+import { IntermediatePackageMetadata } from './package-operations';
+
+/**
+ * Gets the dependency graph of the monorepo's packages. In the graph, each
+ * monorepo package is a node, and there is a directed edge from PackageA
+ * to PackageB if PackageA lists PackageB in any of the dependency fields in its
+ * `package.json`.
+ *
+ * @param intermediatePackageMetadata - The intermediate package metadata of all
+ * monorepo packages.
+ * @returns The internal dependency graph of the monorepo.
+ */
+export function getMonorepoDependencyGraph(
+  intermediatePackageMetadata: ReadonlyMap<string, IntermediatePackageMetadata>,
+): DepGraph<string> {
+  // Initialize the dependency graph object. Before we can record dependencies,
+  // we have to add every package as a node.
+  const dependencyGraph = new DepGraph<string>({ circular: true });
+  for (const packageName of intermediatePackageMetadata.keys()) {
+    dependencyGraph.addNode(packageName);
+  }
+
+  // Next, iterate over every dependency field of every `package.json` file in
+  // the monorepo, and record the internal dependencies for each package. Then
+  // return the complete graph.
+  for (const [packageName, { manifest }] of intermediatePackageMetadata) {
+    getInternalDependencies(manifest, intermediatePackageMetadata).forEach(
+      (dependencyName) => {
+        dependencyGraph.addDependency(packageName, dependencyName);
+      },
+    );
+  }
+  return dependencyGraph;
+}
+
+/**
+ * Gets the list of monorepo packages depended on by a particular monorepo
+ * package.
+ *
+ * @param manifest - The `package.json` file of the package.
+ * @param intermediatePackageMetadata - The intermediate package metadata of all
+ * monorepo packages.
+ * @returns The dependencies internal to the monorepo of the specified package.
+ */
+export function getInternalDependencies(
+  manifest: PackageManifest,
+  intermediatePackageMetadata: ReadonlyMap<string, IntermediatePackageMetadata>,
+): string[] {
+  return Object.values(ManifestDependencyFieldNames).reduce<string[]>(
+    (internalDependencies, fieldName) => {
+      if (Object.hasOwnProperty.call(manifest, fieldName)) {
+        for (const packageName of intermediatePackageMetadata.keys()) {
+          if (Object.hasOwnProperty.call(manifest[fieldName], packageName)) {
+            internalDependencies.push(packageName);
+          }
+        }
+      }
+
+      return internalDependencies;
+    },
+    [],
+  );
+}

--- a/src/package-operations.test.ts
+++ b/src/package-operations.test.ts
@@ -9,9 +9,10 @@ import * as autoChangelog from '@metamask/auto-changelog';
 import * as gitOps from './git-operations';
 import {
   getMetadataForAllPackages,
-  getPackagesToUpdate,
   updatePackage,
   updatePackages,
+  updatePackageChangelog,
+  updateRepoRootManifest,
 } from './package-operations';
 
 jest.mock('fs', () => ({
@@ -131,50 +132,6 @@ describe('package-operations', () => {
         [names[1]]: getMockPackageMetadata(1),
         [names[2]]: getMockPackageMetadata(2),
       });
-    });
-  });
-
-  describe('getPackagesToUpdate', () => {
-    let didPackageChangeMock: jest.SpyInstance;
-
-    const packageNames = ['name1', 'name2', 'name3'];
-
-    const mockMetadataRecord = {
-      [packageNames[0]]: {},
-      [packageNames[1]]: {},
-      [packageNames[2]]: {},
-    };
-
-    beforeEach(() => {
-      didPackageChangeMock = jest.spyOn(gitOps, 'didPackageChange');
-    });
-
-    it('returns all packages if synchronizeVersions is true', async () => {
-      expect(
-        await getPackagesToUpdate(mockMetadataRecord as any, true, new Set()),
-      ).toStrictEqual(new Set(packageNames));
-      expect(didPackageChangeMock).not.toHaveBeenCalled();
-    });
-
-    it('returns changed packages if synchronizeVersions is false', async () => {
-      didPackageChangeMock
-        .mockImplementationOnce(async () => false)
-        .mockImplementationOnce(async () => true)
-        .mockImplementationOnce(async () => false);
-
-      expect(
-        await getPackagesToUpdate(mockMetadataRecord as any, false, new Set()),
-      ).toStrictEqual(new Set([packageNames[1]]));
-      expect(didPackageChangeMock).toHaveBeenCalledTimes(3);
-    });
-
-    it('throws an error if there are no packages to update', async () => {
-      didPackageChangeMock.mockImplementation(async () => false);
-
-      await expect(
-        getPackagesToUpdate(mockMetadataRecord as any, false, new Set()),
-      ).rejects.toThrow(/no packages to update/u);
-      expect(didPackageChangeMock).toHaveBeenCalledTimes(3);
     });
   });
 

--- a/src/package-operations.ts
+++ b/src/package-operations.ts
@@ -9,14 +9,20 @@ import {
   validatePolyrepoPackageManifest,
   writeJsonFile,
 } from '@metamask/action-utils';
+import type { DepGraph } from 'dependency-graph';
 import { didPackageChange } from './git-operations';
+import { getMonorepoDependencyGraph } from './graph-utils';
 import { VersionSynchronizationStrategies, WORKSPACE_ROOT } from './utils';
 
-export interface PackageMetadata {
+export interface IntermediatePackageMetadata {
   readonly dirName: string;
   readonly manifest: PackageManifest;
   readonly name: string;
   readonly dirPath: string;
+}
+
+export interface PackageMetadata extends IntermediatePackageMetadata {
+  readonly shouldUpdate: boolean;
 }
 
 interface UpdateSpecification {
@@ -24,8 +30,14 @@ interface UpdateSpecification {
   readonly repositoryUrl: string;
 }
 
-interface MonorepoUpdateSpecification extends UpdateSpecification {
-  readonly allPackageMetadata: Record<string, PackageMetadata>;
+export interface MonorepoUpdateSpecification extends UpdateSpecification {
+  readonly allPackageMetadata: ReadonlyMap<string, PackageMetadata>;
+  /**
+   * The set of packages that have changed since the previous release. This is
+   * in some cases needed in the update specification to determine whether to
+   * update the version ranges of internal monorepo packages where they appear
+   * as dependencies.
+   */
   readonly changedPackages: ReadonlySet<string>;
   readonly versionSyncStrategy: VersionSynchronizationStrategies;
   readonly shouldUpdateChangelog: boolean;
@@ -35,8 +47,9 @@ const MANIFEST_FILE_NAME = 'package.json';
 const CHANGELOG_FILE_NAME = 'CHANGELOG.md';
 
 /**
- * Finds the package manifest for each workspace, and collects
- * metadata for each package.
+ * Finds the package manifest for each workspace, determines which packages
+ * have changed since the last release, and collects necessary metadata for
+ * about package.
  *
  * @param workspaces - The list of workspace patterns given in the root manifest.
  * @param tags - All tags for the release's base git branch.
@@ -51,13 +64,18 @@ export async function getMetadataForAllPackages(
   tags: ReadonlySet<string>,
   versionSyncStrategy: VersionSynchronizationStrategies,
   rootDir: string = WORKSPACE_ROOT,
-): Promise<[Record<string, PackageMetadata>, ReadonlySet<string>]> {
+): Promise<[ReadonlyMap<string, PackageMetadata>, ReadonlySet<string>]> {
   const workspaceLocations = await getWorkspaceLocations(workspaces, rootDir);
 
-  let hasChangedPackages = false;
-  const allPackageMetadata: Record<string, PackageMetadata> = {};
+  // These are populated in the .map() below.
   const changedPackages: Set<string> = new Set();
+  const intermediatePackageMetadata: Map<
+    string,
+    IntermediatePackageMetadata | PackageMetadata
+  > = new Map();
 
+  // We could have reduced here, but instead we parallelize our operations using
+  // Promise.all.
   await Promise.all(
     workspaceLocations.map(async (packagePath) => {
       const fullWorkspacePath = pathUtils.join(rootDir, packagePath);
@@ -69,33 +87,145 @@ export async function getMetadataForAllPackages(
         );
         const { name: packageName } = manifest;
 
-        // Record package metadata
-        allPackageMetadata[packageName] = {
+        // Record whether package changed. If we're synchronizing the versions
+        // of all packages, regard all packages as changed. Otherwise, go by the
+        // git history.
+        if (
+          versionSyncStrategy === VersionSynchronizationStrategies.all ||
+          (await didPackageChange(tags, manifest, packagePath))
+        ) {
+          changedPackages.add(packageName);
+        }
+
+        // Record intermediate package metadata.
+        intermediatePackageMetadata.set(packageName, {
           dirName: pathUtils.basename(packagePath),
           manifest,
           name: packageName,
           dirPath: packagePath,
-        };
-
-        // Record whether package changed
-        const didChange = await didPackageChange(tags, manifest, packagePath);
-        if (didChange) {
-          changedPackages.add(packageName);
-        }
-        hasChangedPackages = hasChangedPackages || didChange;
+        });
       }
     }),
   );
 
-  // If no packages were changed, and our strategy is not to bump the versions
-  // of all packages, there's nothing to do, and we exit with an error.
+  // If our strategy is not to bump the versions of all packages and no packages
+  // changed, there's nothing to do, and we exit with an error.
   if (
-    !hasChangedPackages &&
-    versionSyncStrategy !== VersionSynchronizationStrategies.all
+    versionSyncStrategy !== VersionSynchronizationStrategies.all &&
+    changedPackages.size === 0
   ) {
     throw new Error(`There are no packages to update.`);
   }
-  return [allPackageMetadata, changedPackages];
+
+  return [
+    getCompletePackageMetadata(
+      intermediatePackageMetadata,
+      changedPackages,
+      versionSyncStrategy,
+    ),
+    changedPackages,
+  ];
+}
+
+/**
+ * Given the intermediate equivalent, gets the _complete_ metadata for all
+ * packages in the monorepo, which amounts to a boolean for each package
+ * indicating whether it should be updated. This is computed by analyzing the
+ * monorepo's dependency graph.
+ *
+ * @param intermediatePackageMetadata - The intermediate package metadata of all
+ * monorepo packages.
+ * @param changedPackages - The set of packages that have changed.
+ * @param versionSyncStrategy - The version synchronization strategy.
+ * @returns The complete package metadata for all packages in the monorepo.
+ */
+export function getCompletePackageMetadata(
+  intermediatePackageMetadata: ReadonlyMap<string, IntermediatePackageMetadata>,
+  changedPackages: ReadonlySet<string>,
+  versionSyncStrategy: VersionSynchronizationStrategies,
+): ReadonlyMap<string, PackageMetadata> {
+  const dependencyGraph = getMonorepoDependencyGraph(
+    intermediatePackageMetadata,
+  );
+
+  // This mutable set will be modified as the dependency graph is traversed.
+  const packagesToUpdate = new Set(changedPackages.values());
+
+  /**
+   * Sidebar: Topological order
+   *
+   * "...a topological sort or topological ordering of a directed graph is a
+   * linear ordering of its vertices such that for every directed edge uv from
+   * vertex u to vertex v, u comes before v in the ordering."
+   * Ref: https://en.wikipedia.org/wiki/Topological_sorting
+   *
+   * In our usage, there is a directed edge from PackageA to PackageB if
+   * PackageA lists PackageB in any of the dependency fields in its
+   * `package.json`.
+   *
+   * `overallOrder` is a convention of the `dependency-graph` library, which by
+   * all appearances is the opposite of topological order.
+   * Ref: https://github.com/jriecken/dependency-graph/tree/072cdcc3eef1ee4531114e7a675e3cbe828fb33e#examples
+   */
+
+  // Traverse the monorepo's internal dependency graph in topological order.
+  return dependencyGraph
+    .overallOrder() // leaves -> root
+    .reverse() // root -> leaves (topological order)
+    .reduce((fullPackageMetadata, packageName) => {
+      const shouldUpdate = shouldUpdateMonorepoPackage(
+        packageName,
+        packagesToUpdate,
+        dependencyGraph,
+        versionSyncStrategy,
+      );
+
+      // Update the set of packages that will be updated in preparation for the
+      // next iteration.
+      if (shouldUpdate) {
+        packagesToUpdate.add(packageName);
+      }
+
+      fullPackageMetadata.set(packageName, {
+        // Every package is in the dependency graph, so we know that the key exists.
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        ...intermediatePackageMetadata.get(packageName)!,
+        shouldUpdate,
+      });
+      return fullPackageMetadata;
+    }, new Map<string, PackageMetadata>());
+}
+
+/**
+ * **ATTN:** This function must be called on each monorepo package in
+ * topological order of dependency in order to return valid results.
+ *
+ * Gets whether the specified package should be updated, given the set of
+ * dependents of this package that will be updated, the monorepo dependency
+ * graph, and the active version synchronization strategy.
+ *
+ * @param packageName - The name of the package to check.
+ * @param packagesToUpdate - The (mutable) set of packages that will be updated.
+ * @param dependencyGraph - The monorepo's internal dependency graph.
+ * @param versionSyncStrategy - The version synchronization strategy.
+ * @returns Whether the package should be updated to the new version.
+ */
+export function shouldUpdateMonorepoPackage(
+  packageName: string,
+  packagesToUpdate: Set<string>,
+  dependencyGraph: DepGraph<string>,
+  versionSyncStrategy: VersionSynchronizationStrategies,
+): boolean {
+  const shouldUpdate =
+    versionSyncStrategy === VersionSynchronizationStrategies.all ||
+    packagesToUpdate.has(packageName) ||
+    dependencyGraph
+      .dependenciesOf(packageName)
+      .reduce<boolean>((hasChangedDependency, dependencyName) => {
+        return hasChangedDependency || packagesToUpdate.has(dependencyName);
+      }, false);
+
+  return shouldUpdate;
 }
 
 /**
@@ -109,13 +239,13 @@ export async function getMetadataForAllPackages(
  *
  * @param updateSpecification - The update specification.
  */
-export async function updatePackages(
+export async function updateMonorepoPackages(
   updateSpecification: MonorepoUpdateSpecification,
 ): Promise<void> {
   const { allPackageMetadata } = updateSpecification;
   await Promise.all(
-    Object.keys(allPackageMetadata).map(async (packageName) =>
-      updatePackage(allPackageMetadata[packageName], updateSpecification),
+    Array.from(allPackageMetadata.values()).map(async (packageMetadata) =>
+      updateMonorepoPackage(packageMetadata, updateSpecification),
     ),
   );
 }
@@ -134,7 +264,7 @@ export async function updatePackages(
  * the update is performed.
  * @param rootDir - The path to the repository root directory.
  */
-export async function updatePackage(
+async function updateMonorepoPackage(
   packageMetadata: PackageMetadata,
   updateSpecification: MonorepoUpdateSpecification,
   rootDir: string = WORKSPACE_ROOT,
@@ -144,7 +274,7 @@ export async function updatePackage(
       pathUtils.join(rootDir, packageMetadata.dirPath, MANIFEST_FILE_NAME),
       getUpdatedManifest(packageMetadata, updateSpecification),
     ),
-    updateSpecification.shouldUpdateChangelog
+    packageMetadata.shouldUpdate && updateSpecification.shouldUpdateChangelog
       ? updatePackageChangelog(packageMetadata, updateSpecification)
       : Promise.resolve(),
   ]);
@@ -234,18 +364,14 @@ function getUpdatedManifest(
   packageMetadata: PackageMetadata,
   updateSpecification: UpdateSpecification | MonorepoUpdateSpecification,
 ): PackageManifest {
-  const { manifest: currentManifest } = packageMetadata;
+  const { manifest: currentManifest, shouldUpdate } = packageMetadata;
   const { newVersion } = updateSpecification;
-  if (
-    isMonorepoUpdateSpecification(updateSpecification) &&
-    updateSpecification.versionSyncStrategy !==
-      VersionSynchronizationStrategies.none
-  ) {
+  if (isMonorepoUpdateSpecification(updateSpecification)) {
     // Synchronize monorepo package versions wherever they appear as a dependency.
     return {
       ...currentManifest,
       ...getUpdatedDependencyFields(currentManifest, updateSpecification),
-      version: newVersion,
+      version: shouldUpdate ? newVersion : currentManifest.version,
     };
   }
 
@@ -266,20 +392,12 @@ function getUpdatedDependencyFields(
   currentManifest: Partial<PackageManifest>,
   updateSpecification: MonorepoUpdateSpecification,
 ): Partial<Pick<PackageManifest, ManifestDependencyFieldNames>> {
-  const {
-    newVersion,
-    changedPackages,
-    versionSyncStrategy,
-  } = updateSpecification;
-
   return Object.values(ManifestDependencyFieldNames).reduce(
     (newDepsFields: Record<string, unknown>, fieldName) => {
-      if (fieldName in currentManifest) {
+      if (Object.hasOwnProperty.call(currentManifest, fieldName)) {
         newDepsFields[fieldName] = getUpdatedDependencyField(
           currentManifest[fieldName] as Record<string, string>,
-          newVersion,
-          versionSyncStrategy,
-          changedPackages,
+          updateSpecification,
         );
       }
 
@@ -302,20 +420,28 @@ function getUpdatedDependencyFields(
  */
 function getUpdatedDependencyField(
   dependencyObject: Record<string, string>,
-  newVersion: string,
-  versionSyncStrategy: VersionSynchronizationStrategies,
-  changedPackages: ReadonlySet<string>,
+  updateSpecification: MonorepoUpdateSpecification,
 ): Record<string, string> {
+  const {
+    allPackageMetadata,
+    changedPackages,
+    newVersion,
+    versionSyncStrategy,
+  } = updateSpecification;
+
   const newVersionRange = `^${newVersion}`;
+
   return Object.keys(dependencyObject).reduce(
     (newDeps: Record<string, string>, packageName) => {
-      newDeps[packageName] = shouldUpdateDependencyVersion(
-        packageName,
-        versionSyncStrategy,
-        changedPackages,
-      )
-        ? newVersionRange
-        : dependencyObject[packageName];
+      if (allPackageMetadata.has(packageName)) {
+        newDeps[packageName] = shouldUpdateDependencyVersion(
+          packageName,
+          versionSyncStrategy,
+          changedPackages,
+        )
+          ? newVersionRange
+          : dependencyObject[packageName];
+      }
 
       return newDeps;
     },
@@ -338,7 +464,8 @@ function shouldUpdateDependencyVersion(
     case VersionSynchronizationStrategies.all:
       return true;
 
-    case VersionSynchronizationStrategies.dependenciesOnly:
+    case VersionSynchronizationStrategies.transitive:
+    case VersionSynchronizationStrategies.internalOnly:
       return changedPackages.has(packageName);
 
     case VersionSynchronizationStrategies.none:

--- a/src/package-operations.ts
+++ b/src/package-operations.ts
@@ -91,7 +91,7 @@ export async function getMetadataForAllPackages(
         // of all packages, regard all packages as changed. Otherwise, go by the
         // git history.
         if (
-          versionSyncStrategy === VersionSynchronizationStrategies.all ||
+          versionSyncStrategy === VersionSynchronizationStrategies.fixed ||
           (await didPackageChange(tags, manifest, packagePath))
         ) {
           changedPackages.add(packageName);
@@ -111,7 +111,7 @@ export async function getMetadataForAllPackages(
   // If our strategy is not to bump the versions of all packages and no packages
   // changed, there's nothing to do, and we exit with an error.
   if (
-    versionSyncStrategy !== VersionSynchronizationStrategies.all &&
+    versionSyncStrategy !== VersionSynchronizationStrategies.fixed &&
     changedPackages.size === 0
   ) {
     throw new Error(`There are no packages to update.`);
@@ -217,7 +217,7 @@ export function shouldUpdateMonorepoPackage(
   versionSyncStrategy: VersionSynchronizationStrategies,
 ): boolean {
   const shouldUpdate =
-    versionSyncStrategy === VersionSynchronizationStrategies.all ||
+    versionSyncStrategy === VersionSynchronizationStrategies.fixed ||
     packagesToUpdate.has(packageName) ||
     dependencyGraph
       .dependenciesOf(packageName)
@@ -461,15 +461,12 @@ function shouldUpdateDependencyVersion(
   changedPackages: ReadonlySet<string>,
 ): boolean {
   switch (versionSyncStrategy) {
-    case VersionSynchronizationStrategies.all:
+    case VersionSynchronizationStrategies.fixed:
       return true;
 
     case VersionSynchronizationStrategies.transitive:
-    case VersionSynchronizationStrategies.internalOnly:
+    case VersionSynchronizationStrategies.independent:
       return changedPackages.has(packageName);
-
-    case VersionSynchronizationStrategies.none:
-      return false;
 
     default:
       throw new Error(

--- a/src/update.test.ts
+++ b/src/update.test.ts
@@ -33,7 +33,7 @@ jest.mock('./package-operations', () => {
     getMetadataForAllPackages: jest.fn(),
     getPackagesToUpdate: jest.fn(),
     updatePackage: jest.fn(),
-    updatePackages: jest.fn(),
+    updateMonorepoPackages: jest.fn(),
   };
 });
 
@@ -188,8 +188,8 @@ describe('performUpdate', () => {
       new Set(['v1.0.0', 'v1.1.0']),
     );
 
-    expect(packageOperations.updatePackages).toHaveBeenCalledTimes(1);
-    expect(packageOperations.updatePackages).toHaveBeenCalledWith(
+    expect(packageOperations.updateMonorepoPackages).toHaveBeenCalledTimes(1);
+    expect(packageOperations.updateMonorepoPackages).toHaveBeenCalledWith(
       { a: {}, b: {}, c: {} },
       {
         newVersion,
@@ -271,8 +271,8 @@ describe('performUpdate', () => {
       new Set(['v1.0.0', 'v1.1.0']),
     );
 
-    expect(packageOperations.updatePackages).toHaveBeenCalledTimes(1);
-    expect(packageOperations.updatePackages).toHaveBeenCalledWith(
+    expect(packageOperations.updateMonorepoPackages).toHaveBeenCalledTimes(1);
+    expect(packageOperations.updateMonorepoPackages).toHaveBeenCalledWith(
       { a: {}, b: {}, c: {} },
       {
         newVersion,
@@ -354,8 +354,8 @@ describe('performUpdate', () => {
       new Set(['v0.0.0', 'v0.1.0']),
     );
 
-    expect(packageOperations.updatePackages).toHaveBeenCalledTimes(1);
-    expect(packageOperations.updatePackages).toHaveBeenCalledWith(
+    expect(packageOperations.updateMonorepoPackages).toHaveBeenCalledTimes(1);
+    expect(packageOperations.updateMonorepoPackages).toHaveBeenCalledWith(
       { a: {}, b: {}, c: {} },
       {
         newVersion,

--- a/src/update.ts
+++ b/src/update.ts
@@ -17,8 +17,9 @@ import { getRepositoryHttpsUrl, getTags } from './git-operations';
 import {
   getMetadataForAllPackages,
   updateRepoRootManifest,
-  updatePackages,
+  updateMonorepoPackages,
   updatePackageChangelog,
+  MonorepoUpdateSpecification,
 } from './package-operations';
 import {
   ActionInputs,
@@ -69,7 +70,7 @@ export async function performUpdate(actionInputs: ActionInputs): Promise<void> {
   } else if (isMajorSemverDiff(versionDiff)) {
     versionSyncStrategy = VersionSynchronizationStrategies.all;
   } else {
-    versionSyncStrategy = VersionSynchronizationStrategies.dependenciesOnly;
+    versionSyncStrategy = VersionSynchronizationStrategies.transitive;
   }
 
   // Ensure that the new version is greater than the current version, and that
@@ -156,7 +157,7 @@ async function updateMonorepo(
     versionSyncStrategy,
   );
 
-  const updateSpecification = {
+  const updateSpecification: MonorepoUpdateSpecification = {
     allPackageMetadata,
     changedPackages,
     newVersion,
@@ -170,7 +171,7 @@ async function updateMonorepo(
   // this Action.
   await Promise.all([
     updateRepoRootManifest(rootManifest, updateSpecification),
-    updatePackages(updateSpecification),
+    updateMonorepoPackages(updateSpecification),
   ]);
 }
 

--- a/src/update.ts
+++ b/src/update.ts
@@ -68,7 +68,7 @@ export async function performUpdate(actionInputs: ActionInputs): Promise<void> {
   if (actionInputs.VersionSynchronizationStrategy) {
     versionSyncStrategy = actionInputs.VersionSynchronizationStrategy;
   } else if (isMajorSemverDiff(versionDiff)) {
-    versionSyncStrategy = VersionSynchronizationStrategies.all;
+    versionSyncStrategy = VersionSynchronizationStrategies.fixed;
   } else {
     versionSyncStrategy = VersionSynchronizationStrategies.transitive;
   }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -2,6 +2,8 @@ import {
   AcceptedSemverReleaseTypes,
   getActionInputs,
   InputKeys,
+  InputNames,
+  VersionSynchronizationStrategies,
 } from './utils';
 
 jest.mock('fs', () => ({
@@ -14,15 +16,20 @@ jest.mock('fs', () => ({
 const mockProcessEnv = ({
   releaseType,
   releaseVersion,
+  versionSyncStrategy,
 }: {
   releaseType?: string;
   releaseVersion?: string;
+  versionSyncStrategy?: VersionSynchronizationStrategies;
 }) => {
   if (releaseType !== undefined) {
     process.env[InputKeys.ReleaseType] = releaseType;
   }
   if (releaseVersion !== undefined) {
     process.env[InputKeys.ReleaseVersion] = releaseVersion;
+  }
+  if (versionSyncStrategy !== undefined) {
+    process.env[InputKeys.VersionSynchronizationStrategy] = versionSyncStrategy;
   }
 };
 
@@ -35,25 +42,44 @@ describe('getActionInputs', () => {
     unmockProcessEnv();
   });
 
-  it('correctly parses valid input: release-type', () => {
-    for (const releaseType of Object.values(AcceptedSemverReleaseTypes)) {
+  it(`correctly parses valid input: ${InputNames.ReleaseType}`, () => {
+    Object.values(AcceptedSemverReleaseTypes).forEach((releaseType) => {
       mockProcessEnv({ releaseType });
+
       expect(getActionInputs()).toStrictEqual({
         ReleaseType: releaseType,
         ReleaseVersion: null,
+        VersionSynchronizationStrategy: null,
       });
-    }
+    });
   });
 
-  it('correctly parses valid input: release-version', () => {
-    const versions = ['1.0.0', '2.0.0', '1.0.1', '0.1.0'];
-    for (const releaseVersion of versions) {
+  it(`correctly parses valid input: ${InputNames.ReleaseVersion}`, () => {
+    ['1.0.0', '2.0.0', '1.0.1', '0.1.0'].forEach((releaseVersion) => {
       mockProcessEnv({ releaseVersion });
+
       expect(getActionInputs()).toStrictEqual({
         ReleaseType: null,
         ReleaseVersion: releaseVersion,
+        VersionSynchronizationStrategy: null,
       });
-    }
+    });
+  });
+
+  it(`correctly parses valid input: ${InputNames.VersionSynchronizationStrategy}`, () => {
+    const releaseVersion = '1.0.0';
+
+    Object.values(VersionSynchronizationStrategies).forEach(
+      (versionSyncStrategy) => {
+        mockProcessEnv({ versionSyncStrategy, releaseVersion });
+
+        expect(getActionInputs()).toStrictEqual({
+          ReleaseType: null,
+          ReleaseVersion: releaseVersion,
+          VersionSynchronizationStrategy: versionSyncStrategy,
+        });
+      },
+    );
   });
 
   it('throws if neither "release-type" nor "release-version" are specified', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,36 +26,35 @@ export enum VersionSynchronizationStrategies {
    * monorepo package will be updated to the new version wherever it appears as
    * a dependency.
    *
-   * This is the default behavior if the release is a new major version.
+   * The published versions of all monorepo packages are "fixed".
+   *
+   * This is the default behavior _if_ the release is a new major version.
    */
-  all = 'all',
+  fixed = 'fixed',
 
   /**
    * Changed packages and their dependents in the monorepo will be updated to
    * the new version, and the version of every monorepo package will be updated
    * to the new version wherever it appears as a dependency.
    *
+   * The published versions of all monorepo packages will reflect their
+   * dependency relationships.
+   *
    * This is the default behavior _unless_ the release is a new major version.
    */
   transitive = 'transitive',
 
   /**
-   * Only changed packages will be updated to the new version, but the version
+   * Only changed packages will be updated to the new version, and the version
    * of every monorepo package will be updated to the new version wherever it
-   * appears as a dependency.
+   * appears as a dependency. Synchronizing the monorepo package versions
+   * internally is necessary for the functioning of `yarn`'s workspace feature.
+   *
+   * The the published versions of all monorepo packages are "independent".
    *
    * This is never the default behavior.
    */
-  internalOnly = 'internalOnly',
-
-  /**
-   * Only changed packages will be updated to the new version, and no version of
-   * any monorepo package will be updated to a new version where it appears as a
-   * dependency.
-   *
-   * This is never the default behavior.
-   */
-  none = 'none',
+  independent = 'independent',
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,25 +26,34 @@ export enum VersionSynchronizationStrategies {
    * monorepo package will be updated to the new version wherever it appears as
    * a dependency.
    *
-   * This is the default if the release is a new major version.
+   * This is the default behavior if the release is a new major version.
    */
   all = 'all',
+
+  /**
+   * Changed packages and their dependents in the monorepo will be updated to
+   * the new version, and the version of every monorepo package will be updated
+   * to the new version wherever it appears as a dependency.
+   *
+   * This is the default behavior _unless_ the release is a new major version.
+   */
+  transitive = 'transitive',
 
   /**
    * Only changed packages will be updated to the new version, but the version
    * of every monorepo package will be updated to the new version wherever it
    * appears as a dependency.
    *
-   * This is the default _unless_ the release is a new major version.
+   * This is never the default behavior.
    */
-  dependenciesOnly = 'dependenciesOnly',
+  internalOnly = 'internalOnly',
 
   /**
    * Only changed packages will be updated to the new version, and no version of
    * any monorepo package will be updated to a new version where it appears as a
    * dependency.
    *
-   * This is never the default.
+   * This is never the default behavior.
    */
   none = 'none',
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1570,6 +1570,11 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
+dependency-graph@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/dependency-graph/-/dependency-graph-0.11.0.tgz#ac0ce7ed68a54da22165a85e97a01d53f5eb2e27"
+  integrity sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==
+
 detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"


### PR DESCRIPTION
This PR adds finer-grained monorepo version synchronization strategies to this action. Previously, when releasing this action, you could either bump the version of all packages or just packages with a git diff since the previous release. The former case was internally referred to as "version synchronization".

These two strategies do not cover all cases of version synchronization. For example, in [a recent release](https://github.com/MetaMask/snaps-skunkworks/pull/277) of a monorepo that uses this action, a faulty `postinstall` script was added to a package (`snaps-cli`). This caused installation of this package to fail for consumers, _even if the package was only a transitive dependency_. To fix this, both the offending package _and_ its dependents in the monorepo needed to be updated and re-published. Since the dependents had not changed since the previous release, [doing this](https://github.com/MetaMask/snaps-skunkworks/pull/283) required considerable manual labor.

In addition, synchronizing the version of and then releasing _all_ packages causes those packages that change infrequently to have a lot of empty release, e.g. [this one](https://github.com/MetaMask/snaps-skunkworks/blob/1b09897d356e7242f9fdc8253c5a289652e94631/packages/types/CHANGELOG.md).

To address these shortcomings, this PR adds a new input to this action, `version-synchronization-strategies`, which handles version synchronization in one of the following ways:
- `fixed`
  - Updates the version of all packages the new version, including wherever they appear as dependencies.
  - This is the current behavior of this action for major releases and any releases if the major version is `0`.
  - This remains the default for major releases in the new implementation.
- `transitive`
  - Updates changed packages _and their dependents_ to the new version. Also updates dependency references.
  - This is the default for non-major releases in the new implementation.
- `independent`
  - Only updates changed packages to the new version. Dependency references are updated, but the version of dependents are not updated unless they were in the original set of changed packages.
  - This option is the current behavior for non-major releases. It ensures that `yarn`'s workspace feature works correctly, but it may create issues of the form described above.
    - In a `yarn` v1 workspace (I haven't tested other versions), if a monorepo package appears as a dependency with a version different from that of the local monorepo package, `yarn` will fetch it from the registry. This kind of defeats the purpose of the monorepo, so I've decided to make this situation impossible if you use this action.
  - Think of this as the "off" option. It is never the default in the new implementation.

The `transitive` strategy is made possible by something that this action did not have before: the internal dependency graph of the monorepo, in topological order. This is made possible using the [`dependency-graph`](https://npmjs.com/package/dependency-graph) npm package.

Fixes #79 