### PR TITLE
Create build-only tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "build:clean": "yarn rimraf 'lib/*' 'dist/*'",
-    "build:tsc": "tsc --project .",
+    "build:tsc": "tsc --project tsconfig.build.json",
     "build:ncc": "ncc build lib/index.js --out dist",
     "build": "yarn build:clean && yarn build:tsc && yarn build:ncc",
     "test": "jest",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "inlineSources": true,
+    "noEmit": false,
+    "outDir": "lib",
+    "rootDir": "src",
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,12 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "esModuleInterop": true,
-    "inlineSources": true,
     "lib": ["ES2020"],
     "module": "ES6",
-    "moduleResolution": "Node",
-    "outDir": "lib",
-    "rootDir": "src",
-    "sourceMap": true,
+    "moduleResolution": "node",
+    "noEmit": true,
     "strict": true,
-    "target": "ES2019",
-    "typeRoots": ["node_modules/@types"]
+    "target": "ES2019"
   },
-  "exclude": ["src/**/*.test.ts"],
-  "include": ["src/**/*.ts"]
+  "exclude": ["./dist/**/*", "./lib/**/*"]
 }


### PR DESCRIPTION
These changes are copied from the [module template][1]. The main goal
here is to expand TypeScript's purview so that it includes test files,
improving the overall development experience. We also remove `typeRoots`
from the config (because the value provided is already the default) and
add `exclude`s in the default `tsconfig.json` (for consistency with the
module template).

[1]: https://github.com/MetaMask/metamask-module-template/pull/102