### PR TITLE
Retry getting the release PR number on a timeout

### DIFF
--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -69,7 +69,21 @@ fi
 
 if [[ -n $ARTIFACTS_DIR_PATH ]]; then
   # Write PR number to file so that it can be uploaded as an artifact
-  PR_NUMBER=$(gh pr view --json number | jq '.number')
+
+  # Retry getting the number on a timeout in case GitHub is slow to create the PR
+  PR_NUMBER=''
+  for i in {1..7} # 6 + 1 times total
+  do
+    PR_NUMBER=$(gh pr view --json number | jq '.number')
+    if [[ -z $PR_NUMBER ]]; then
+      break
+    fi
+
+    # sleep 6 times for 10 seconds each, for a total of 60 seconds
+    if (( i < 7)); then
+      sleep 10
+    fi
+  done
 
   if [[ -z $PR_NUMBER ]]; then
     echo 'Error: "gh pr view" did not return a PR number.'


### PR DESCRIPTION
Recently, this action [failed](https://github.com/MetaMask/post-message-stream/runs/7096918602?check_suite_focus=true) because we failed to get the release PR number via `gh pr view`, despite the fact that the PR was created successfully. I hypothesize that this happened because we didn't give GitHub enough time to create the PR and return its number to us. This PR ensures that we retry `gh pr view` on a 10-second interval for a total of 60 seconds, to give GitHub enough time to return the result we're looking for.