### PR TITLE
Remove `set-output`

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -31,7 +31,7 @@ jobs:
           ref: ${{ github.event.inputs.base-branch }}
       - name: Get Node.js version
         id: nvm
-        run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
+        run: echo "NODE_VERSION=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -23,7 +23,7 @@ jobs:
           ref: ${{ github.event.pull_request.base.ref }}
       - name: Get Node.js version
         id: nvm
-        run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
+        run: echo "NODE_VERSION=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}

--- a/.github/workflows/scripts/update-major-version-tag.sh
+++ b/.github/workflows/scripts/update-major-version-tag.sh
@@ -28,4 +28,4 @@ git tag "$MAJOR_VERSION_TAG" HEAD
 git push --tags
 echo "Updated shorthand major version tag."
 
-echo "MAJOR_VERSION_TAG=$MAJOR_VERSION_TAG" >> $GITHUB_OUTPUT
+echo "MAJOR_VERSION_TAG=$MAJOR_VERSION_TAG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/scripts/update-major-version-tag.sh
+++ b/.github/workflows/scripts/update-major-version-tag.sh
@@ -28,4 +28,4 @@ git tag "$MAJOR_VERSION_TAG" HEAD
 git push --tags
 echo "Updated shorthand major version tag."
 
-echo "::set-output name=MAJOR_VERSION_TAG::$MAJOR_VERSION_TAG"
+echo "MAJOR_VERSION_TAG=$MAJOR_VERSION_TAG" >> $GITHUB_OUTPUT


### PR DESCRIPTION
re: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

continuation after missing some things in #98 