### PR TITLE
Check for `workspace:^` before replacing the version in package.json

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
       - run: yarn install --frozen-lockfile
       - run: yarn setup:postinstall
       - run: yarn build

--- a/dist/index.js
+++ b/dist/index.js
@@ -15037,7 +15037,7 @@ function getUpdatedDependencyField(dependencyObject, packagesToUpdate, newVersio
     return Object.keys(dependencyObject).reduce((newDeps, packageName) => {
         newDeps[packageName] =
             packagesToUpdate.has(packageName) &&
-                dependencyObject[packageName] !== 'workspace:^'
+                !dependencyObject[packageName].startsWith('workspace:')
                 ? newVersionRange
                 : dependencyObject[packageName];
         return newDeps;

--- a/dist/index.js
+++ b/dist/index.js
@@ -15035,9 +15035,11 @@ function getUpdatedDependencyFields(manifest, updateSpecification) {
 function getUpdatedDependencyField(dependencyObject, packagesToUpdate, newVersion) {
     const newVersionRange = `^${newVersion}`;
     return Object.keys(dependencyObject).reduce((newDeps, packageName) => {
-        newDeps[packageName] = packagesToUpdate.has(packageName)
-            ? newVersionRange
-            : dependencyObject[packageName];
+        newDeps[packageName] =
+            packagesToUpdate.has(packageName) &&
+                dependencyObject[packageName] !== 'workspace:^'
+                ? newVersionRange
+                : dependencyObject[packageName];
         return newDeps;
     }, {});
 }

--- a/src/package-operations.ts
+++ b/src/package-operations.ts
@@ -356,7 +356,7 @@ function getUpdatedDependencyField(
     (newDeps: Record<string, string>, packageName) => {
       newDeps[packageName] =
         packagesToUpdate.has(packageName) &&
-        dependencyObject[packageName] !== 'workspace:^'
+        !dependencyObject[packageName].startsWith('workspace:')
           ? newVersionRange
           : dependencyObject[packageName];
 

--- a/src/package-operations.ts
+++ b/src/package-operations.ts
@@ -354,9 +354,11 @@ function getUpdatedDependencyField(
   const newVersionRange = `^${newVersion}`;
   return Object.keys(dependencyObject).reduce(
     (newDeps: Record<string, string>, packageName) => {
-      newDeps[packageName] = packagesToUpdate.has(packageName)
-        ? newVersionRange
-        : dependencyObject[packageName];
+      newDeps[packageName] =
+        packagesToUpdate.has(packageName) &&
+        dependencyObject[packageName] !== 'workspace:^'
+          ? newVersionRange
+          : dependencyObject[packageName];
 
       return newDeps;
     },


### PR DESCRIPTION
## Description

This pull request modifies the `getUpdatedDependencyField` function to avoid overriding the dependencies that should not
be updated. The update process should ignore certain dependencies that are used across multiple packages in a workspace.

The change involves introducing a check for the presence of `workspace:^` in the `package.json` file before updating
the version. This is an important step because `workspace:^` should not be overridden with new version ranges. The rest
of the dependency versions can be updated, however.

## Changes

1. Added a check for `workspace:^` in `getUpdatedDependencyField` that prevents updating the version range for this dependency.