### PR TITLE
BREAKING: Format changelog using Prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,10 @@
   "dependencies": {
     "@actions/core": "^1.10.0",
     "@metamask/action-utils": "^1.0.0",
-    "@metamask/auto-changelog": "^3.1.0",
+    "@metamask/auto-changelog": "^3.3.0",
     "execa": "^4.1.0",
     "glob": "^7.1.7",
+    "prettier": "^2.8.8",
     "semver": "^7.3.5"
   },
   "devDependencies": {
@@ -73,7 +74,6 @@
     "eslint-plugin-prettier": "^3.4.0",
     "jest": "^28.1.0",
     "lodash.clonedeep": "^4.5.0",
-    "prettier": "^2.2.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^28.0.3",
     "typescript": "~4.3.0"

--- a/src/package-operations.test.ts
+++ b/src/package-operations.test.ts
@@ -9,6 +9,7 @@ import * as autoChangelog from '@metamask/auto-changelog';
 import glob from 'glob';
 import * as gitOps from './git-operations';
 import {
+  formatChangelog,
   getMetadataForAllPackages,
   getPackagesToUpdate,
   updatePackage,
@@ -22,6 +23,7 @@ jest.mock('fs', () => ({
     readFile: jest.fn(),
     writeFile: jest.fn(),
   },
+  existsSync: jest.fn(),
 }));
 
 jest.mock('glob');
@@ -345,6 +347,7 @@ describe('package-operations', () => {
           isReleaseCandidate: true,
           projectRootDirectory: dir,
           repoUrl,
+          formatter: expect.any(Function),
         });
 
         expect(writeFileMock).toHaveBeenNthCalledWith(
@@ -468,6 +471,7 @@ describe('package-operations', () => {
           isReleaseCandidate: true,
           projectRootDirectory: dir,
           repoUrl,
+          formatter: expect.any(Function),
         });
       });
 
@@ -516,6 +520,7 @@ describe('package-operations', () => {
           isReleaseCandidate: true,
           projectRootDirectory: dir,
           repoUrl,
+          formatter: expect.any(Function),
         });
       });
 
@@ -641,6 +646,32 @@ describe('package-operations', () => {
           }),
         );
       });
+    });
+  });
+
+  describe('formatChangelog', () => {
+    it('formats a changelog', () => {
+      const unformattedChangelog = `#  Changelog
+##     1.0.0
+
+ - Some change
+## 0.0.1
+
+- Some other change
+`;
+
+      expect(formatChangelog(unformattedChangelog)).toMatchInlineSnapshot(`
+        "# Changelog
+
+        ## 1.0.0
+
+        - Some change
+
+        ## 0.0.1
+
+        - Some other change
+        "
+      `);
     });
   });
 });

--- a/src/package-operations.ts
+++ b/src/package-operations.ts
@@ -215,6 +215,17 @@ export async function updatePackage(
 }
 
 /**
+ * Format the given changelog using Prettier. This is extracted into a separate
+ * function for coverage purposes.
+ *
+ * @param changelog - The changelog to format.
+ * @returns The formatted changelog.
+ */
+export function formatChangelog(changelog: string) {
+  return prettier.format(changelog, { parser: 'markdown' });
+}
+
+/**
  * Updates the changelog file of the given package, using
  * `@metamask/auto-changelog`. Assumes that the changelog file is located at the
  * package root directory and named "CHANGELOG.md".
@@ -260,8 +271,7 @@ async function updatePackageChangelog(
     isReleaseCandidate: true,
     projectRootDirectory,
     repoUrl: repositoryUrl,
-    formatter: (changelog) =>
-      prettier.format(changelog, { parser: 'markdown' }),
+    formatter: formatChangelog,
   });
   if (!newChangelogContent) {
     const packageName = packageMetadata.manifest.name;

--- a/src/package-operations.ts
+++ b/src/package-operations.ts
@@ -13,6 +13,7 @@ import {
   validatePolyrepoPackageManifest,
   writeJsonFile,
 } from '@metamask/action-utils';
+import prettier from 'prettier';
 import { didPackageChange } from './git-operations';
 import { WORKSPACE_ROOT, isErrorWithCode } from './utils';
 
@@ -259,6 +260,8 @@ async function updatePackageChangelog(
     isReleaseCandidate: true,
     projectRootDirectory,
     repoUrl: repositoryUrl,
+    formatter: (changelog) =>
+      prettier.format(changelog, { parser: 'markdown' }),
   });
   if (!newChangelogContent) {
     const packageName = packageMetadata.manifest.name;

--- a/yarn.lock
+++ b/yarn.lock
@@ -665,13 +665,14 @@
     glob "^7.1.7"
     semver "^7.3.5"
 
-"@metamask/auto-changelog@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@metamask/auto-changelog/-/auto-changelog-3.1.0.tgz#d4d6bc7b9a1244a2e6a8ff1f818540b6491d8d88"
-  integrity sha512-o+4XljQzTvd46ML+PRyCNv3B9EbFf6JjaaueB2+v/aWSf97pp6FmjEXSPwaUzQQhl9GkaZj8himpanT62Nv9Aw==
+"@metamask/auto-changelog@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@metamask/auto-changelog/-/auto-changelog-3.3.0.tgz#9b9c2c4e4f5d65d85abcb3d9f6eedc32ea4518fd"
+  integrity sha512-Azv5WhR8N6iFUqcVfogM+aqkj/vWNv7CXD9TeSdlE1eoKV/TVtDe/dhRz+SjFJ8KK3u1dBuIrYypb2qBTh8Q8A==
   dependencies:
     diff "^5.0.0"
     execa "^5.1.1"
+    prettier "^2.8.8"
     semver "^7.3.5"
     yargs "^17.0.1"
 
@@ -3382,10 +3383,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
-  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+prettier@^2.8.8:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 pretty-format@^26.0.0, pretty-format@^26.6.2:
   version "26.6.2"


### PR DESCRIPTION
MetaMask/auto-changelog#155 adds a method to format changelogs using Prettier. I've enabled this option here.

This is a breaking change, since it will change the default formatting of the changelog in new release PRs. Packages updating to the next version of this package should simultaneously enable the `--prettier` flag on `auto-changelog`.

# Breaking changes

- The default formatting of the changelog will change.
- For this to be properly linted, [`auto-changelog` should be updated to run with the `--prettier` flag](https://github.com/MetaMask/metamask-module-template/pull/219/commits/29f1b97089f468461680f326c3b6ae3fb0f99a17).