### PR TITLE
chore: declare yarn version 1.22.22 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   ],
   "main": "lib/index.js",
   "engines": {
-    "node": "^18.16 || >=20"
+    "node": "^18.16 || >=20",
+    "yarn": "^1.22.22"
   },
   "scripts": {
     "setup": "yarn install && yarn setup:postinstall",
@@ -84,5 +85,6 @@
     "allowScripts": {
       "@lavamoat/preinstall-always-fail": false
     }
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
Pin current (latest) yarn v1.x version in order to make `corepack enable` pick up the correct version when working with this repo.

### Related
- https://github.com/MetaMask/metamask-mobile/pull/9143
- https://github.com/MetaMask/action-utils/pull/35