### PR TITLE
chore: Update codeowners to `MetaMask/core-platform`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-*                                   @MetaMask/wallet-framework-engineers
+* @MetaMask/core-platform


### PR DESCRIPTION
Wallet Framework is now part of Core Platform.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to repository ownership metadata; it only affects review assignment/notifications, not runtime behavior.
> 
> **Overview**
> Updates `.github/CODEOWNERS` to switch the default repository owner from `@MetaMask/wallet-framework-engineers` to `@MetaMask/core-platform`, changing who is requested for reviews across the codebase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d343bdca1bb231ebfd8cfc3145c6b14ba44b91b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->