### PR TITLE
ci: Run CI on `ubuntu-latest`

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-lint-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -23,7 +23,7 @@ jobs:
       - run: yarn test
 
   all-tests-pass:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: build-lint-test
     steps:
       - run: echo "Great success"


### PR DESCRIPTION
Some steps were still running on `ubuntu-20.04`, which does not seem to be supported anymore.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that updates the runner image; main risk is unexpected environment/tooling differences on the newer Ubuntu version causing CI failures.
> 
> **Overview**
> Runs the `build-lint-test` and `all-tests-pass` GitHub Actions jobs on `ubuntu-latest` (replacing `ubuntu-20.04`) to keep CI using a supported runner image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a033d29055f33f723e39a770dd044bc44d4f561d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->