### PR TITLE
feat!: Automatically categorize changelog entries with conventional commit type

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -46103,6 +46103,7 @@ async function updatePackageChangelog(packageMetadata, updateSpecification, root
         projectRootDirectory,
         repoUrl: repositoryUrl,
         formatter: formatChangelog,
+        autoCategorize: true,
     });
     if (newChangelogContent) {
         return await external_fs_.promises.writeFile(changelogPath, newChangelogContent);

--- a/src/package-operations.test.ts
+++ b/src/package-operations.test.ts
@@ -317,6 +317,7 @@ describe('package-operations', () => {
           currentVersion: newVersion,
           isReleaseCandidate: true,
           projectRootDirectory: dir,
+          autoCategorize: true,
           repoUrl,
           formatter: expect.any(Function),
         });
@@ -457,6 +458,7 @@ describe('package-operations', () => {
           currentVersion: newVersion,
           isReleaseCandidate: true,
           projectRootDirectory: dir,
+          autoCategorize: true,
           repoUrl,
           formatter: expect.any(Function),
         });
@@ -521,6 +523,7 @@ describe('package-operations', () => {
           currentVersion: newVersion,
           isReleaseCandidate: true,
           projectRootDirectory: dir,
+          autoCategorize: true,
           repoUrl,
           formatter: expect.any(Function),
         });
@@ -590,6 +593,7 @@ describe('package-operations', () => {
           currentVersion: newVersion,
           isReleaseCandidate: true,
           projectRootDirectory: dir,
+          autoCategorize: true,
           repoUrl,
           formatter: expect.any(Function),
         });

--- a/src/package-operations.ts
+++ b/src/package-operations.ts
@@ -283,6 +283,7 @@ async function updatePackageChangelog(
     projectRootDirectory,
     repoUrl: repositoryUrl,
     formatter: formatChangelog,
+    autoCategorize: true,
   });
 
   if (newChangelogContent) {


### PR DESCRIPTION
This enables the `autoCategorize` option on `auto-changelog`, which automatically categorizes entries based on the conventional commit type.

Closes #159.

## Breaking changes

- The generated changelog is now different for commits with conventional commit types.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release/changelog generation behavior (including a breaking output format change), which could affect downstream tooling or expectations during publishing, but does not touch runtime product logic or security-sensitive code.
> 
> **Overview**
> Enables `autoCategorize` when calling `@metamask/auto-changelog` during `updatePackageChangelog`, causing generated changelog entries to be grouped by conventional commit type.
> 
> Updates unit tests and the built `dist/index.js` bundle to assert/pass the new `autoCategorize: true` option through to `updateChangelog`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7d029097f95bceacb5780cd5d977b20921f835c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->