### PR TITLE
feat: support Git operations with GitHub token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,8 +24,7 @@ inputs:
     default: 'prettier'
     required: false
   github-token:
-    description: 'The GitHub token used to authenticate git operations and create the pull request. Defaults to `github.token`.'
-    default: ${{ github.token }}
+    description: 'The GitHub token used to authenticate git operations and create the pull request. Defaults to the `GITHUB_TOKEN` environment variable.'
     required: false
 
 runs:
@@ -42,14 +41,15 @@ runs:
         RELEASE_TYPE: ${{ inputs.release-type }}
         RELEASE_VERSION: ${{ inputs.release-version }}
         FORMATTER: ${{ inputs.formatter }}
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GIT_TOKEN: ${{ inputs.github-token || env.GITHUB_TOKEN }}
         GIT_CONFIG_COUNT: 1
         GIT_CONFIG_KEY_0: credential.https://github.com.helper
-        GIT_CONFIG_VALUE_0: '!f() { echo username=x-access-token; echo password=${GITHUB_TOKEN}; }; f'
+        GIT_CONFIG_VALUE_0: '!f() { echo username=x-access-token; echo password=${GIT_TOKEN}; }; f'
     - id: create-release-pr
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GH_TOKEN: ${{ inputs.github-token || env.GITHUB_TOKEN }}
+        GIT_TOKEN: ${{ inputs.github-token || env.GITHUB_TOKEN }}
       run: |
         ${{ github.action_path }}/scripts/create-release-pr.sh \
           ${{ steps.update-packages.outputs.NEW_VERSION }} \

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,6 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token || env.GITHUB_TOKEN || github.token }}
-        GIT_TOKEN: ${{ inputs.github-token || env.GITHUB_TOKEN || github.token }}
       run: |
         ${{ github.action_path }}/scripts/create-release-pr.sh \
           ${{ steps.update-packages.outputs.NEW_VERSION }} \

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     default: 'prettier'
     required: false
   github-token:
-    description: 'The GitHub token used to authenticate git operations and create the pull request. Defaults to the `GITHUB_TOKEN` environment variable.'
+    description: 'The GitHub token used to authenticate git operations and create the pull request. Defaults to `github.token`.'
     required: false
 
 runs:
@@ -41,15 +41,15 @@ runs:
         RELEASE_TYPE: ${{ inputs.release-type }}
         RELEASE_VERSION: ${{ inputs.release-version }}
         FORMATTER: ${{ inputs.formatter }}
-        GIT_TOKEN: ${{ inputs.github-token || env.GITHUB_TOKEN }}
+        GIT_TOKEN: ${{ inputs.github-token || github.token }}
         GIT_CONFIG_COUNT: 1
         GIT_CONFIG_KEY_0: credential.https://github.com.helper
         GIT_CONFIG_VALUE_0: '!f() { echo username=x-access-token; echo password=${GIT_TOKEN}; }; f'
     - id: create-release-pr
       shell: bash
       env:
-        GH_TOKEN: ${{ inputs.github-token || env.GITHUB_TOKEN }}
-        GIT_TOKEN: ${{ inputs.github-token || env.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ inputs.github-token || github.token }}
+        GIT_TOKEN: ${{ inputs.github-token || github.token }}
       run: |
         ${{ github.action_path }}/scripts/create-release-pr.sh \
           ${{ steps.update-packages.outputs.NEW_VERSION }} \

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'The formatter to use when updating CHANGELOG.md files. Allowed options are "oxfmt" and "prettier".'
     default: 'prettier'
     required: false
+  github-token:
+    description: 'The GitHub token used to authenticate git operations and create the pull request. Defaults to `github.token`.'
+    default: ${{ github.token }}
+    required: false
 
 runs:
   using: 'composite'
@@ -40,6 +44,8 @@ runs:
         FORMATTER: ${{ inputs.formatter }}
     - id: create-release-pr
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
         ${{ github.action_path }}/scripts/create-release-pr.sh \
           ${{ steps.update-packages.outputs.NEW_VERSION }} \

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,10 @@ runs:
         RELEASE_TYPE: ${{ inputs.release-type }}
         RELEASE_VERSION: ${{ inputs.release-version }}
         FORMATTER: ${{ inputs.formatter }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GIT_CONFIG_COUNT: 1
+        GIT_CONFIG_KEY_0: credential.https://github.com.helper
+        GIT_CONFIG_VALUE_0: "!f() { echo username=x-access-token; echo password=${GITHUB_TOKEN}; }; f"
     - id: create-release-pr
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,9 @@ runs:
         RELEASE_VERSION: ${{ inputs.release-version }}
         FORMATTER: ${{ inputs.formatter }}
         GIT_TOKEN: ${{ inputs.github-token || env.GITHUB_TOKEN || github.token }}
+        # This is needed to support `auto-changlog` when credentials are not
+        # persisted by the checkout action.
+        # See: https://github.com/MetaMask/auto-changelog/issues/291.
         GIT_CONFIG_COUNT: 1
         GIT_CONFIG_KEY_0: credential.https://github.com.helper
         GIT_CONFIG_VALUE_0: '!f() { echo username=x-access-token; echo password=${GIT_TOKEN}; }; f'

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     default: 'prettier'
     required: false
   github-token:
-    description: 'The GitHub token used to authenticate git operations and create the pull request. Defaults to `github.token`.'
+    description: 'The GitHub token used to authenticate git operations and create the pull request. Defaults to the `GITHUB_TOKEN` environment variable, or `github.token` if not set.'
     required: false
 
 runs:
@@ -41,15 +41,15 @@ runs:
         RELEASE_TYPE: ${{ inputs.release-type }}
         RELEASE_VERSION: ${{ inputs.release-version }}
         FORMATTER: ${{ inputs.formatter }}
-        GIT_TOKEN: ${{ inputs.github-token || github.token }}
+        GIT_TOKEN: ${{ inputs.github-token || env.GITHUB_TOKEN || github.token }}
         GIT_CONFIG_COUNT: 1
         GIT_CONFIG_KEY_0: credential.https://github.com.helper
         GIT_CONFIG_VALUE_0: '!f() { echo username=x-access-token; echo password=${GIT_TOKEN}; }; f'
     - id: create-release-pr
       shell: bash
       env:
-        GH_TOKEN: ${{ inputs.github-token || github.token }}
-        GIT_TOKEN: ${{ inputs.github-token || github.token }}
+        GH_TOKEN: ${{ inputs.github-token || env.GITHUB_TOKEN || github.token }}
+        GIT_TOKEN: ${{ inputs.github-token || env.GITHUB_TOKEN || github.token }}
       run: |
         ${{ github.action_path }}/scripts/create-release-pr.sh \
           ${{ steps.update-packages.outputs.NEW_VERSION }} \

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         GIT_CONFIG_COUNT: 1
         GIT_CONFIG_KEY_0: credential.https://github.com.helper
-        GIT_CONFIG_VALUE_0: "!f() { echo username=x-access-token; echo password=${GITHUB_TOKEN}; }; f"
+        GIT_CONFIG_VALUE_0: '!f() { echo username=x-access-token; echo password=${GITHUB_TOKEN}; }; f'
     - id: create-release-pr
       shell: bash
       env:

--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -52,7 +52,7 @@ then
     exit 1
 fi
 
-git push --set-upstream origin "${RELEASE_BRANCH_NAME}"
+git push --set-upstream "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${RELEASE_BRANCH_NAME}"
 
 if [[ "$CREATED_PR_STATUS" = "draft" ]]; then
   gh pr create \

--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -52,7 +52,7 @@ then
     exit 1
 fi
 
-git push --set-upstream "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${RELEASE_BRANCH_NAME}"
+git push --set-upstream "https://x-access-token:${GIT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${RELEASE_BRANCH_NAME}"
 
 if [[ "$CREATED_PR_STATUS" = "draft" ]]; then
   gh pr create \

--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -52,7 +52,7 @@ then
     exit 1
 fi
 
-git push --set-upstream "https://x-access-token:${GIT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${RELEASE_BRANCH_NAME}"
+git push --set-upstream "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${RELEASE_BRANCH_NAME}"
 
 if [[ "$CREATED_PR_STATUS" = "draft" ]]; then
   gh pr create \


### PR DESCRIPTION
## Summary

- Adds a `github-token` input (defaulting to `github.token`) to the action
- Passes the token as `GITHUB_TOKEN` to the create-release-pr step, where `gh` CLI picks it up automatically
- Uses the token inline in the `git push` URL instead of relying on persisted checkout credentials, supporting workflows that use `persist-credentials: false`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how credentials are supplied for push and git HTTPS operations; misconfigured or under-scoped tokens could break releases, but behavior is backward-compatible when the default token is used.
> 
> **Overview**
> Adds an optional **`github-token`** input that resolves to `inputs.github-token`, then `GITHUB_TOKEN`, then `github.token`, so release workflows can supply a token explicitly instead of depending on checkout-persisted credentials.
> 
> The **update-packages** step now sets **`GIT_TOKEN`** and a one-entry **`GIT_CONFIG_*` credential helper** so git HTTPS calls (e.g. from auto-changelog) use `x-access-token` when checkout used `persist-credentials: false`. The **create-release-pr** step sets **`GH_TOKEN`** for `gh`, and **`git push`** targets an authenticated `https://x-access-token:${GH_TOKEN}@github.com/...` URL instead of the default remote.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e55d2d947e70b86e106199f176c1c3d7021b57cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->